### PR TITLE
Harden build fingerprinting and polish loading state

### DIFF
--- a/cacao/frontend/build.js
+++ b/cacao/frontend/build.js
@@ -214,8 +214,15 @@ function contentHash(filePath) {
 
 const manifest = {};
 
-// Fingerprint all CSS and JS files in dist/
-const distFiles = fs.readdirSync(distDir).filter(f => f.endsWith('.css') || f.endsWith('.js'));
+// Fingerprint only base (non-fingerprinted) CSS and JS files in dist/
+// Base files have at most one dot (the extension), e.g. "cacao.js", "cacao-core.css"
+// Fingerprinted files have extra dot-separated hashes, e.g. "cacao.abc123.js"
+const baseNames = new Set([
+  'cacao.js', 'cacao.css',
+  'cacao-core.css', 'cacao-cat-layout.css', 'cacao-cat-display.css',
+  'cacao-cat-typography.css', 'cacao-cat-form.css', 'cacao-cat-charts.css',
+]);
+const distFiles = fs.readdirSync(distDir).filter(f => baseNames.has(f));
 
 for (const file of distFiles) {
   const filePath = path.join(distDir, file);

--- a/cacao/frontend/src/components/App.js
+++ b/cacao/frontend/src/components/App.js
@@ -157,7 +157,7 @@ export function App({ renderers }) {
   }
 
   if (error) return h('div', { className: 'loading', style: { color: 'var(--danger)' } }, 'Error: ' + error);
-  if (!pages) return h('div', { className: 'loading' }, 'Loading...');
+  if (!pages) return h('div', { className: 'loading' }, h('div', { className: 'loading-spinner' }));
 
   const pageData = pages.pages || {};
   const components = pageData[currentPage] || [];

--- a/cacao/frontend/src/components/renderer.js
+++ b/cacao/frontend/src/components/renderer.js
@@ -78,7 +78,7 @@ export function renderComponent(comp, key, setActiveTab, activeTab, renderers) {
   const children = (comp.children || []).map((c, i) => renderComponent(c, i, setActiveTab, activeTab, renderers));
   const element = h(
     ErrorBoundary,
-    { key, componentType: comp.type, type: comp.type },
+    { key, componentType: comp.type, type: comp.type, props: comp.props || {} },
     h(Renderer, { props: comp.props || {}, children, setActiveTab, activeTab, type: comp.type }),
   );
 

--- a/cacao/frontend/src/styles/base.less
+++ b/cacao/frontend/src/styles/base.less
@@ -31,11 +31,27 @@ body {
 // Loading state
 .loading {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   height: 100vh;
+  width: 100%;
   color: var(--text-muted);
   font-size: @font-size-base;
+  gap: 12px;
+}
+
+.loading-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--bg-tertiary);
+  border-top-color: var(--accent-primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }
 
 // Global focus ring for keyboard navigation


### PR DESCRIPTION
The build was fingerprinting its own fingerprinted files — a ouroboros of hashes eating hashes. This PR locks fingerprinting to a known set of base dist files and swaps the plain-text "Loading..." for a proper spinner, while also forwarding component props through the error boundary.

<details>
<summary>Technical changes</summary>

- `build.js`: Replace greedy `.css`/`.js` glob with an explicit `baseNames` allowlist so only canonical dist files (`cacao.js`, `cacao.css`, category CSS) get fingerprinted — prevents re-hashing already-fingerprinted copies
- `App.js`: Replace text "Loading..." placeholder with a `.loading-spinner` element for a visual loading indicator
- `base.less`: Add `.loading-spinner` CSS animation (32px bordered circle, `spin` keyframe at 0.8s) and adjust `.loading` container to column layout with gap
- `renderer.js`: Forward `comp.props` into the `ErrorBoundary` wrapper so boundary components have access to the rendered component's props
- Removed stale root `VERSION` file

</details>
